### PR TITLE
more friendlier inventory, remove unnecessary items, random somethings make them looks more real

### DIFF
--- a/src/packets/out/userinfo/fulluserupdate.ts
+++ b/src/packets/out/userinfo/fulluserupdate.ts
@@ -421,4 +421,3 @@ export class UserInfoFullUpdate {
         outPacket.writeUInt8(this.unk84)
     }
 }
-

--- a/src/packets/out/userinfo/fulluserupdate.ts
+++ b/src/packets/out/userinfo/fulluserupdate.ts
@@ -421,3 +421,4 @@ export class UserInfoFullUpdate {
         outPacket.writeUInt8(this.unk84)
     }
 }
+

--- a/src/packets/out/userinfo/fulluserupdate.ts
+++ b/src/packets/out/userinfo/fulluserupdate.ts
@@ -27,7 +27,7 @@ export class UserInfoFullUpdate {
     private unk03: number
     // end of flag & 0x8
     // flag & 0x10
-    private unk04: number
+    private rank: number
     private unk05: number
     // end of flag & 0x10
     // flag & 0x20
@@ -122,7 +122,7 @@ export class UserInfoFullUpdate {
     private unk60: number
     // end of flag & 0x400000
     // flag & 0x800000
-    private unk61: number
+    private icon: number
     // end of flag & 0x800000
     // flag & 0x1000000
     private unk62: number
@@ -131,9 +131,9 @@ export class UserInfoFullUpdate {
     private unk63: number[] // it must always be 0x80 long
     // end of flag & 0x2000000
     // flag & 0x4000000
-    private unk64: number
-    private unk65: number
-    private unk66: number
+    private vip: number
+    private viplevel: number
+    private vipexp: number
     // end of flag & 0x4000000
     // flag & 0x8000000
     private unk67: number
@@ -171,7 +171,7 @@ export class UserInfoFullUpdate {
         this.curExp = user.curExp
         this.maxExp = user.maxExp
         this.unk03 = 0x0313
-        this.unk04 = 0
+        this.rank = user.rank
         this.unk05 = 0
         this.unk06 = new Uint64LE(0x7AF3)
         this.unk07 = 0x0A
@@ -248,7 +248,7 @@ export class UserInfoFullUpdate {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00]
         this.unk60 = 0xA5C8
-        this.unk61 = 0x03ED
+        this.icon = 1006
         this.unk62 = 0
         this.unk63 = [0x00, 0x00, 0x18, 0x08, 0x00, 0x00, 0x00, 0x00, 0x42, 0x02,
             0x18, 0xC0, 0x09, 0x08, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
@@ -261,9 +261,9 @@ export class UserInfoFullUpdate {
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x10, 0x00, 0x00, 0x00, 0x00, 0x00,
             0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0x3E, 0x00, 0x00]
-        this.unk64 = 0
-        this.unk65 = 0
-        this.unk66 = 0
+        this.vip = 1
+        this.viplevel = user.viplevel
+        this.vipexp = 180000
         this.unk67 = 0
         this.unk68 = new Uint64LE(0x02FB)
         this.unk69 = new Uint64LE(0x19AC)
@@ -302,7 +302,7 @@ export class UserInfoFullUpdate {
         outPacket.writeUInt64(this.maxExp)
         outPacket.writeUInt32(this.unk03)
 
-        outPacket.writeUInt8(this.unk04)
+        outPacket.writeUInt8(this.rank)
         outPacket.writeUInt8(this.unk05)
 
         outPacket.writeUInt64(this.unk06)
@@ -386,7 +386,7 @@ export class UserInfoFullUpdate {
         }
         outPacket.writeUInt32(this.unk60)
 
-        outPacket.writeUInt16(this.unk61)
+        outPacket.writeUInt16(this.icon)
 
         outPacket.writeUInt16(this.unk62)
 
@@ -394,9 +394,9 @@ export class UserInfoFullUpdate {
             outPacket.writeUInt8(elem)
         }
 
-        outPacket.writeUInt8(this.unk64)
-        outPacket.writeUInt8(this.unk65)
-        outPacket.writeUInt32(this.unk66)
+        outPacket.writeUInt8(this.vip)
+        outPacket.writeUInt8(this.viplevel)
+        outPacket.writeUInt32(this.vipexp)
 
         outPacket.writeUInt32(this.unk67)
 

--- a/src/room/room.ts
+++ b/src/room/room.ts
@@ -630,6 +630,20 @@ export class Room {
             case RoomGamemode.deathmatch:
             case RoomGamemode.original:
             case RoomGamemode.originalmr:
+            case RoomGamemode.casualbomb:
+            case RoomGamemode.casualoriginal:
+            case RoomGamemode.eventmod01:
+            case RoomGamemode.eventmod02:
+            case RoomGamemode.diy:
+            case RoomGamemode.campaign1:
+            case RoomGamemode.campaign2:
+            case RoomGamemode.campaign3:
+            case RoomGamemode.campaign4:
+            case RoomGamemode.campaign5:
+            case RoomGamemode.tdm_small:
+            case RoomGamemode.de_small:
+            case RoomGamemode.madcity:
+            case RoomGamemode.madcity_team:
             case RoomGamemode.gunteamdeath:
             case RoomGamemode.gunteamdeath_re:
             case RoomGamemode.stealth:
@@ -638,13 +652,14 @@ export class Room {
                 if (this.getNumOfReadyPlayers() < 2) {
                     return false
                 }
-                break
             case RoomGamemode.giant:
             case RoomGamemode.hide:
             case RoomGamemode.hide2:
+            case RoomGamemode.hide_match:
             case RoomGamemode.hide_origin:
             case RoomGamemode.hide_Item:
             case RoomGamemode.hide_multi:
+            case RoomGamemode.ghost:
             case RoomGamemode.pig:
             case RoomGamemode.tag:
             case RoomGamemode.zombie:
@@ -655,13 +670,6 @@ export class Room {
                 if (this.getNumOfReadyRealPlayers() < 2) {
                     return false
                 }
-                break
-            case RoomGamemode.z_scenario_side:
-            case RoomGamemode.endless_wave:
-            case RoomGamemode.play_ground:
-            case RoomGamemode.practice:
-            default:
-                break
         }
 
         return true

--- a/src/user/user.ts
+++ b/src/user/user.ts
@@ -30,6 +30,8 @@ export class User {
     public level: number
     public curExp: Uint64LE
     public maxExp: Uint64LE
+    public rank: number
+    public viplevel: number
     public wins: number
     public kills: number
     public deaths: number
@@ -55,13 +57,15 @@ export class User {
         this.currentChannelIndex = 0
 
         this.userName = userName
-        this.level = 1
-        this.curExp = new Uint64LE(0)
-        this.maxExp = new Uint64LE(1000)
+        this.level = Math.floor(Math.random() * Math.floor(100))
+        this.rank = Math.floor(Math.random() * Math.floor(21))
+        this.viplevel = Math.floor(Math.random() * Math.floor(7))
+        this.curExp = new Uint64LE(Math.floor(Math.random() * Math.floor(1000000)))
+        this.maxExp = new Uint64LE(1000000)
         this.wins = 0
-        this.kills = 0
-        this.deaths = 0
-        this.assists = 0
+        this.kills = Math.floor(Math.random() * Math.floor(100000))
+        this.deaths = Math.floor(Math.random() * Math.floor(100000))
+        this.assists = Math.floor(Math.random() * Math.floor(100000))
 
         this.inventory = new UserInventory()
     }

--- a/src/user/userinventory.ts
+++ b/src/user/userinventory.ts
@@ -216,4 +216,3 @@ export class UserInventory {
         }
     }
 }
-

--- a/src/user/userinventory.ts
+++ b/src/user/userinventory.ts
@@ -154,7 +154,7 @@ export class UserInventory {
 
         this.loadouts[loadout].items[slot] = itemId
     }
-    
+
     // block something that shouldn't be there
     // (not including weapon skins, decorations, etc can be fix on client)
     public BlockItems(id: number): boolean {

--- a/src/user/userinventory.ts
+++ b/src/user/userinventory.ts
@@ -216,3 +216,4 @@ export class UserInventory {
         }
     }
 }
+

--- a/src/user/userinventory.ts
+++ b/src/user/userinventory.ts
@@ -18,28 +18,28 @@ export class UserInventory {
     public loadouts: UserLoadout[]
 
     constructor() {
-        this.ctModelItem = 1033
-        this.terModelItem = 1034
-        this.headItem = 10062
-        this.gloveItem = 30018
-        this.backItem = 20042
+        this.ctModelItem = 1047
+        this.terModelItem = 1048
+        this.headItem = 0
+        this.gloveItem = 0
+        this.backItem = 0
         this.stepsItem = 0
-        this.sprayItem = 42003
+        this.sprayItem = 42001
 
         this.buymenu = new UserBuyMenu()
-        this.buymenu.pistols = [5271, 5245, 5358, 5288, 106, 5119, 5121, 5360, 5294]
-        this.buymenu.shotguns = [5130, 5181, 5157, 5282, 5286, 5343, 5264, 5265, 5230]
-        this.buymenu.smgs = [5251, 5295, 162, 5132, 5346, 5320, 5287, 5321, 5310]
-        this.buymenu.rifles = [5136, 5142, 45, 46, 5218, 5240, 5259, 5309, 5370]
-        this.buymenu.snipers = [5133, 5118, 5216, 86, 5338, 5241, 5225, 5369, 5244]
-        this.buymenu.machineguns = [5125, 5289, 5226, 5332, 5352, 5363, 5311, 5260, 5234]
-        this.buymenu.melees = [5353, 5362, 5330, 5303, 5304, 5305, 5365, 5231, 5232]
+        this.buymenu.pistols = [5280, 5279, 5337, 5356, 5294, 5360, 5262, 103, 106]
+        this.buymenu.shotguns = [5130, 5293, 5306, 5261, 5242, 5264, 5265, 5230, 137]
+        this.buymenu.smgs = [5251, 5295, 5238, 5320, 5285, 5347, 5310, 162, 105]
+        this.buymenu.rifles = [46, 45, 5296, 5184, 5355, 113, 102, 161, 157]
+        this.buymenu.snipers = [5133, 5118, 5206, 5241, 5225, 146, 125, 160, 163]
+        this.buymenu.machineguns = [5125, 5314, 5260, 87, 5332, 5366, 5276, 5233, 159]
+        this.buymenu.melees = [79, 5232, 84, 5221, 5304, 5330, 5253, 5231, 5353]
         this.buymenu.equipment = [36, 37, 23, 4, 8, 34, 0, 0, 0]
 
         this.loadouts = [
-            new UserLoadout(5218, 5288, 84, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-            new UserLoadout(5319, 5131, 5353, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
-            new UserLoadout(5220, 5337, 5253, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            new UserLoadout(5336, 5356, 5330, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            new UserLoadout(5285, 5294, 5231, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
+            new UserLoadout(5206, 5356, 5365, 4, 23, 8, 0, 0, 0, 0, 0, 0, 0, 0, 0, 0),
         ]
 
         this.items = []
@@ -60,6 +60,9 @@ export class UserInventory {
             UserInventoryItem.pushItem(userInv, unlock)
         }
         for (let i = 44; i <= 163; i++) {
+            if (this.BlockItems(i)) {
+              continue
+            }
             UserInventoryItem.pushItem(userInv, i)
         }
 
@@ -76,6 +79,9 @@ export class UserInventory {
 
         // weapon skins
         for (let i = 5042; i <= 5370; i++) {
+            if (this.BlockItems(i)) {
+              continue
+            }
             UserInventoryItem.pushItem(userInv, i)
         }
         UserInventoryItem.pushItem(userInv, 5997)
@@ -147,6 +153,29 @@ export class UserInventory {
         }
 
         this.loadouts[loadout].items[slot] = itemId
+    }
+    
+    // block something that shouldn't be there
+    // (not including weapon skins, decorations, etc can be fix on client)
+    public BlockItems(id: number): boolean {
+        switch (id) {
+            case 56:
+            case 58:
+            case 69:
+            case 107:
+            case 117:
+            case 134:
+            case 139:
+            case 5172:
+            case 5173:
+            case 5174:
+            case 5227:
+            case 5228:
+            case 5229:
+              return true
+            default:
+            return false
+        }
     }
 
     /**


### PR DESCRIPTION
I changed the default player buymenu to make them look more friendly, they no longer need to spend some time adding a specific weapon to play a specific mode (In this configuration, they can play all modes without any changes. at least, most :P )
removed some items that couldn't normally see, such as the SS Double Desert Eagle, it can only be transformed by killing a specifie numbers of zombie in a zombie crush. also removed RPG, M16A4M203, TAC-15, and many bugged items in the equipments. (I did not remove weapon skins, decorations, because they can be fix in the client)
it can now also handle those hidden modes, now the way to open hidden mode through the client is almost everyone knows.

and, now the player will be given a random level/rank/KAD/VIP level after login to the game, and I changed the avatar, to be honest, I am tired of watch him, so I don't want to see him anymore!